### PR TITLE
Add fileRef option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Default value: `'<script src="%s"></script>'`
 
 The template used to insert the reference to the script files.
 
+#### options.fileRef
+Type: `Function`
+Default value: `undefined`
+
+Optional function which takes the `filepath` as argument and returns a `String` inserted as reference to the script files. Note that `option.fileRef` takes precedence over `option.fileTmpl`.
+
 #### options.appRoot
 Type: `String`
 Default value: `''`

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The template used to insert the reference to the script files.
 Type: `Function`
 Default value: `undefined`
 
-Optional function which takes the `filepath` as argument and returns a `String` inserted as reference to the script files. Note that `option.fileRef` takes precedence over `option.fileTmpl`.
+Optional function which takes the `filepath` as argument and returns a `String` inserted as reference to the script file. Note that `option.fileRef` takes precedence over `option.fileTmpl`.
 
 #### options.appRoot
 Type: `String`

--- a/tasks/scriptlinker.js
+++ b/tasks/scriptlinker.js
@@ -48,8 +48,8 @@ module.exports = function(grunt) {
 						filepath = filepath.replace(/^\//,'');
 					}
 
-					if (options.fileTmplFn) {
-						return options.fileTmplFn(filepath);
+					if (options.fileRef) {
+						return options.fileRef(filepath);
 					} else {
 						return util.format(options.fileTmpl, filepath);
 					}

--- a/tasks/scriptlinker.js
+++ b/tasks/scriptlinker.js
@@ -47,7 +47,12 @@ module.exports = function(grunt) {
 					if (options.relative) {
 						filepath = filepath.replace(/^\//,'');
 					}
-					return util.format(options.fileTmpl, filepath);
+
+					if (options.fileTmplFn) {
+						return options.fileTmplFn(filepath);
+					} else {
+						return util.format(options.fileTmpl, filepath);
+					}
 				});
 
 			grunt.file.expand({}, f.dest).forEach(function(dest){


### PR DESCRIPTION
This option allow to fully customised the file template. Here is an incredibly useful jade exemple:

```javascript
devTemplatesJade: {
            options: {
                startTag: '// TEMPLATES',
                endTag: '// TEMPLATES END',
                fileTmplFn: function(filepath) {
                    var tmpl = 'script(type="text/ng-template", id="%s"): include ../assets/%s';
                    return util.format(tmpl, filepath.replace(/\.jade/, '.html'), filepath);
                },
                appRoot: 'assets',
                relative: true
            },
            files: {
                'views/**/*.jade': require('../pipeline').templateFilesToInject
            }
}
```